### PR TITLE
修复 README 中的 Star 历史图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ vFlow 目前由两个主要部分组成：运行在 Android 应用进程内的�
 
 ## 🌟来颗 Star
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ChaoMixian/vFlow&type=date&legend=top-left)](https://www.star-history.com/#ChaoMixian/vFlow&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=ChaoMixian/vFlow&type=date&legend=top-left)](https://star-history.dera.page/#ChaoMixian/vFlow&type=date&legend=top-left)
 
 ## 📄 许可证
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -147,7 +147,7 @@ Building a module usually comes down to a few familiar steps: choose the right c
 
 ## 🌟 Star the Project
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ChaoMixian/vFlow&type=date&legend=top-left)](https://www.star-history.com/#ChaoMixian/vFlow&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=ChaoMixian/vFlow&type=date&legend=top-left)](https://star-history.dera.page/#ChaoMixian/vFlow&type=date&legend=top-left)
 
 ## 📄 License
 


### PR DESCRIPTION
当前 README 中的 Star 历史图表因 GitHub 星标接口限制而失效，无法正常展示。

本项目已切换至新的 Star 历史数据源以恢复图表显示，无需额外配置即可正常工作。