### PR TITLE
Fix PP-OCRv5 OpenMP crash and duplicate time trigger delivery

### DIFF
--- a/app/src/main/cpp/ppocr_v5.cpp
+++ b/app/src/main/cpp/ppocr_v5.cpp
@@ -75,6 +75,10 @@ int PPOcrV5::load(const char* detParamPath, const char* detModelPath, const char
     detNet_.clear();
     recNet_.clear();
 
+    ncnn::set_omp_dynamic(0);
+    ncnn::set_omp_num_threads(1);
+
+    detNet_.opt.num_threads = 1;
     detNet_.opt.use_vulkan_compute = false;
     detNet_.opt.use_fp16_packed = useFp16;
     detNet_.opt.use_fp16_storage = useFp16;
@@ -107,7 +111,7 @@ void PPOcrV5::setDictionary(std::vector<std::string> dictionary)
 int PPOcrV5::detect(const cv::Mat& rgb, std::vector<OcrObject>& objects)
 {
     objects.clear();
-    cv::setNumThreads(ncnn::get_big_cpu_count());
+    cv::setNumThreads(1);
 
     int imgW = rgb.cols;
     int imgH = rgb.rows;

--- a/app/src/main/java/com/chaomixian/vflow/services/TimeTriggerReceiver.kt
+++ b/app/src/main/java/com/chaomixian/vflow/services/TimeTriggerReceiver.kt
@@ -4,6 +4,7 @@ package com.chaomixian.vflow.services
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import com.chaomixian.vflow.core.logging.DebugLogger
 import com.chaomixian.vflow.core.workflow.TriggerExecutionCoordinator
 import com.chaomixian.vflow.core.workflow.WorkflowManager
 import com.chaomixian.vflow.core.workflow.model.TriggerSpec
@@ -22,6 +23,23 @@ class TimeTriggerReceiver : BroadcastReceiver() {
         const val EXTRA_WORKFLOW_ID = "workflow_id"
         const val EXTRA_TRIGGER_ID = "trigger_id"
         const val EXTRA_TRIGGER_STEP_ID = "trigger_step_id"
+        private const val DEDUP_PREFS = "time_trigger_dedup"
+        private const val DEDUP_WINDOW_MS = 60_000L
+        private val dedupLock = Any()
+
+        internal fun isDuplicateTimeTrigger(lastTriggeredAt: Long, now: Long): Boolean {
+            return lastTriggeredAt > 0L && now - lastTriggeredAt in 0 until DEDUP_WINDOW_MS
+        }
+
+        private fun claimTimeTrigger(context: Context, triggerId: String, now: Long): Boolean {
+            synchronized(dedupLock) {
+                val prefs = context.getSharedPreferences(DEDUP_PREFS, Context.MODE_PRIVATE)
+                val lastTriggeredAt = prefs.getLong(triggerId, 0L)
+                if (isDuplicateTimeTrigger(lastTriggeredAt, now)) return false
+                prefs.edit().putLong(triggerId, now).commit()
+                return true
+            }
+        }
     }
 
     override fun onReceive(context: Context, intent: Intent) {
@@ -43,6 +61,15 @@ class TimeTriggerReceiver : BroadcastReceiver() {
                     if (workflow != null && triggerStep != null && workflow.isEnabled) {
                         val appContext = context.applicationContext
                         val resolvedTrigger = TriggerSpec(workflow, triggerStep)
+                        if (triggerStep.moduleId == TimeTriggerModule().id &&
+                            !claimTimeTrigger(appContext, resolvedTrigger.triggerId, System.currentTimeMillis())
+                        ) {
+                            DebugLogger.w(
+                                "TimeTriggerReceiver",
+                                "忽略 60 秒内重复送达的定时触发器: ${resolvedTrigger.triggerId}"
+                            )
+                            return@launch
+                        }
                         TriggerExecutionCoordinator.executeTrigger(
                             context = appContext,
                             trigger = resolvedTrigger

--- a/app/src/test/java/com/chaomixian/vflow/services/TimeTriggerReceiverTest.kt
+++ b/app/src/test/java/com/chaomixian/vflow/services/TimeTriggerReceiverTest.kt
@@ -1,0 +1,24 @@
+package com.chaomixian.vflow.services
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TimeTriggerReceiverTest {
+
+    @Test
+    fun `time trigger is duplicate within dedup window`() {
+        assertTrue(TimeTriggerReceiver.isDuplicateTimeTrigger(1_000L, 60_999L))
+    }
+
+    @Test
+    fun `time trigger is accepted at dedup window boundary`() {
+        assertFalse(TimeTriggerReceiver.isDuplicateTimeTrigger(1_000L, 61_000L))
+    }
+
+    @Test
+    fun `first and clock adjusted triggers are accepted`() {
+        assertFalse(TimeTriggerReceiver.isDuplicateTimeTrigger(0L, 1_000L))
+        assertFalse(TimeTriggerReceiver.isDuplicateTimeTrigger(2_000L, 1_000L))
+    }
+}


### PR DESCRIPTION
 ## 变更说明

  本 PR 修复两个在 Android 设备实际运行中发现的稳定性问题：

  1. PP-OCRv5 执行过程中偶发原生崩溃
  2. 固定时间触发器被系统短时间重复投递，导致工作流重复启动

  ## 问题表现

  ### OCR 原生崩溃

  执行 PP-OCRv5 时，应用偶发在 `libppocrv5_jni.so` 中触发 `SIGABRT`，堆栈涉及：

  - `__kmp_affinity_initialize`
  - OpenMP 线程初始化
  - NCNN OCR 推理

  ### 定时任务重复触发

  同一个固定时间闹钟广播可能在短时间内被重复送达。第一次工作流仍在执行时，第二次触发会提示工作流正在执行并被忽略。

  ## 修改内容

  ### OCR 稳定性

  - 禁用 NCNN OpenMP 动态线程调整
  - 将 NCNN 检测和识别网络限制为单线程
  - 将 OpenCV 图像处理限制为单线程

  该修改以部分并行性能换取稳定性，避免特定 Android 设备上的 OpenMP affinity 初始化崩溃。

  ### 固定时间触发器去重

  - 为固定时间触发器增加 60 秒持久化去重窗口
  - 使用 `workflowId:stepId` 作为去重键，避免不同工作流之间发生冲突
  - 使用同步锁保证并发广播只能成功领取一次
  - 仅影响固定时间触发器，不影响手动触发和间隔触发器
  - 应用进程重启后，短时间去重记录仍然有效

  ## 测试

  新增 `TimeTriggerReceiverTest`，覆盖：

  - 60 秒内的重复触发
  - 60 秒边界
  - 首次触发
  - 系统时间回拨

  同时验证：

  - `TimeTriggerReceiverTest` 通过
  - `AlarmTriggerSchedulerTest` 通过
  - Debug APK 构建通过
  - armeabi-v7a、arm64-v8a、x86、x86_64 原生构建通过
  - Android 实机连续执行 OCR 未再出现 `SIGABRT`
  - 固定时间广播重复投递时只执行一次

  ## 提交

  - `fix(ocr): avoid OpenMP affinity crash`
  - `fix(trigger): deduplicate fixed-time alarm delivery`